### PR TITLE
Add default storage backend

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -266,6 +266,9 @@ DEBUG_TOOLBAR_PANELS = [
 ]
 
 STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
     "staticfiles": {
         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
     },


### PR DESCRIPTION
## Summary
- update `STORAGES` to include `default` option

## Testing
- `pipenv run ./manage.py test --noinput --pattern="*_tests.py" -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68407a98e5688325a178b7cda2319c96